### PR TITLE
FIX: `@abstractdataset` in Interfaces

### DIFF
--- a/labrea/dataset.py
+++ b/labrea/dataset.py
@@ -499,8 +499,6 @@ class DatasetFactory(Generic[A]):
             lifted = FunctionApplication.lift(definition, **self.defaults)
             overloads = Overloaded(self.dispatch, {}, lifted)
         else:
-            if self.dispatch == Value(MISSING):
-                raise ValueError("Abstract datasets must have a dispatch")
             overloads = Overloaded(self.dispatch, {})
 
         cache: Cache

--- a/labrea/dataset.py
+++ b/labrea/dataset.py
@@ -385,7 +385,7 @@ class DatasetFactory(Generic[A]):
     dispatch: Evaluatable[Hashable]
     defaults: Dict[str, Evaluatable[Any]]
     options: Options
-    defaut_options: Options
+    default_options: Options
     abstract: bool
 
     def __init__(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -63,10 +63,6 @@ def test_overload_no_dispatch():
 
 
 def test_abstract():
-    with pytest.raises(ValueError):
-        @abstractdataset
-        def x() -> int:
-            pass
 
     @abstractdataset(dispatch='A')
     def x() -> int:

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -2,7 +2,7 @@ import pytest
 
 from labrea.interface import interface, implements
 from labrea.option import Option
-from labrea.dataset import dataset
+from labrea.dataset import dataset, abstractdataset
 from labrea.exceptions import EvaluationError
 
 
@@ -10,40 +10,50 @@ from labrea.exceptions import EvaluationError
 class MyInterface:
     a: str
 
-    def b() -> str:
-        return 'b'
-
     @staticmethod
-    @dataset
+    @abstractdataset
+    def b() -> str:
+        pass
+
     def c() -> str:
         return 'c'
 
-    d: str = Option('D', 'd')
+    @staticmethod
+    @dataset
+    def d() -> str:
+        return 'd'
+
+    e: str = Option('E', 'e')
 
 
 @interface('DISPATCH_2')
 class MyInterface2:
-    e = 'e'
+    f = 'f'
 
 
 def test_no_implementation():
     with pytest.raises(EvaluationError):
         MyInterface.a()
 
-    assert MyInterface.b() == 'b'
+    with pytest.raises(EvaluationError):
+        MyInterface.b()
+
     assert MyInterface.c() == 'c'
     assert MyInterface.d() == 'd'
+    assert MyInterface.e() == 'e'
 
 
 def test_good_implementation():
     @MyInterface.implementation('GOOD')
     class Good:
         a = 'a'
+        b = 'b'
 
     assert MyInterface.a({'DISPATCH': 'GOOD'}) == 'a'
     assert MyInterface.b({'DISPATCH': 'GOOD'}) == 'b'
     assert MyInterface.c({'DISPATCH': 'GOOD'}) == 'c'
     assert MyInterface.d({'DISPATCH': 'GOOD'}) == 'd'
+    assert MyInterface.e({'DISPATCH': 'GOOD'}) == 'e'
 
 
 def test_bad_implementation():
@@ -56,6 +66,17 @@ def test_bad_implementation():
         @MyInterface.implementation('BAD')
         class Bad:
             a = 'a'
+
+    with pytest.raises(TypeError):
+        @MyInterface.implementation('BAD')
+        class Bad:
+            b = 'b'
+
+    with pytest.raises(TypeError):
+        @MyInterface.implementation('BAD')
+        class Bad:
+            a = 'a'
+            b = 'b'
             f = 'f'
 
 
@@ -63,33 +84,37 @@ def test_override():
     @MyInterface.implementation('OVERRIDE')
     class Good:
         a = 'A'
+        b = 'B'
 
-        def b():
-            return 'B'
-
-        @staticmethod
-        @dataset
         def c():
             return 'C'
 
-        d = Option('D', 'D')
+        @staticmethod
+        @dataset
+        def d():
+            return 'D'
+
+        e = Option('E', 'E')
 
     assert MyInterface.a({'DISPATCH': 'OVERRIDE'}) == 'A'
     assert MyInterface.b({'DISPATCH': 'OVERRIDE'}) == 'B'
     assert MyInterface.c({'DISPATCH': 'OVERRIDE'}) == 'C'
     assert MyInterface.d({'DISPATCH': 'OVERRIDE'}) == 'D'
+    assert MyInterface.e({'DISPATCH': 'OVERRIDE'}) == 'E'
 
 
 def test_multi_implementation():
     @implements(MyInterface, MyInterface2, alias='MULTI')
     class Multi:
         a = 'a'
+        b = 'b'
 
     assert MyInterface.a({'DISPATCH': 'MULTI'}) == 'a'
     assert MyInterface.b({'DISPATCH': 'MULTI'}) == 'b'
     assert MyInterface.c({'DISPATCH': 'MULTI'}) == 'c'
     assert MyInterface.d({'DISPATCH': 'MULTI'}) == 'd'
-    assert MyInterface2.e({'DISPATCH_2': 'MULTI'}) == 'e'
+    assert MyInterface.e({'DISPATCH_2': 'MULTI'}) == 'e'
+    assert MyInterface2.f({'DISPATCH_2': 'MULTI'}) == 'f'
 
 
 def test_missing_args():
@@ -114,7 +139,8 @@ def test_invalid_member():
 def test_repr():
     @MyInterface.implementation('A')
     class A:
-        a: int = 1
+        a: str = 'a'
+        b: str = 'b'
 
     assert repr(MyInterface) == '<Interface test_interface.MyInterface>'
     assert repr(A) == '<Implementation test_interface.A of MyInterface>'


### PR DESCRIPTION
## Changelog
- Before this fix, `@abstractdataset` could not be used in interfaces due to no dispatch being provided
- The error being raised when an `@abstractdataset` is created without a dispatch was removed, but an error will still be raised if it is overloaded without a dispatch, which will catch 99% of developer errors