### PR TITLE
Make Overloaded (and thus Dataset) pickleable

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Make the `Dataset` type pickleable
+
 ## Version 2.0.3
 - Fix bug introduced in 2.0.3 where dispatch is called with no options
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 import uuid
+import pickle
 
 from labrea.computation import CallbackEffect
 from labrea.dataset import Dataset, dataset, abstractdataset
@@ -8,7 +9,6 @@ from labrea.exceptions import EvaluationError
 from labrea.logging import LogRequest
 from labrea.option import Option
 import labrea.runtime
-from labrea.types import Evaluatable
 
 
 def test_dataset():
@@ -285,3 +285,9 @@ def test_logging():
         x()
 
     assert handler_run
+
+
+def test_pickle():
+    x = dataset(Option('X'))
+
+    assert isinstance(pickle.loads(pickle.dumps(x)), Dataset)


### PR DESCRIPTION
## Changelog
- Make the `Dataset` type pickleable