### PR TITLE
Add Option Namespaces

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -13,6 +13,7 @@
   + `filter_items`, `filter_keys`, and `filter_values`
     - Analogs of `filter` but for mapping types
 - Modify `PartialApplication` type to work even if multiple arguments are missing
+- Add `@Option.namespace` decorator for creating option namespaces
 
 
 ## Version 2.0.4

--- a/labrea/option.py
+++ b/labrea/option.py
@@ -336,13 +336,13 @@ def WithDefaultOptions(evaluatable: Evaluatable[B], options: Options) -> WithOpt
 
 class _AllOptions(Evaluatable[Options]):
     def evaluate(self, options: Options) -> Options:
-        return resolve(options)
-
-    def validate(self, options: Options) -> None:
         try:
-            _ = resolve(options)
+            return resolve(options)
         except KeyError as e:
             raise KeyNotFoundError(e.args[0], self) from e
+
+    def validate(self, options: Options) -> None:
+        _ = self.evaluate(options)
 
     def keys(self, options: Options) -> Set[str]:
         return set(options.keys())
@@ -453,7 +453,7 @@ class Namespace(Evaluatable[Options]):
 
         members: Dict[str, Union[Option, _Auto, Namespace]] = {}
         for name_ in getattr(__namespace, "__annotations__", {}):
-            members[name] = Option(f"{key}.{name_}")
+            members[name_] = Option(f"{key}.{name_}")
 
         for name_, value in __namespace.__dict__.items():
             if isinstance(value, Namespace):
@@ -522,6 +522,8 @@ class _Auto(Generic[A]):
 
         for tform in self.transformations:
             option = option >> tform
+
+        option.__doc__ = self.doc or option.__doc__
 
         return option
 

--- a/labrea/option.py
+++ b/labrea/option.py
@@ -362,14 +362,14 @@ class Namespace(Evaluatable[Options]):
         for name in getattr(__namespace, "__annotations__", {}):
             members[name] = Option(f"{key}.{name}")
         for name, value in __namespace.__dict__.items():
-            if name.startswith("_"):
-                continue
-            elif isinstance(value, Evaluatable):
+            if isinstance(value, Evaluatable):
                 members[name] = value
-            elif isinstance(value, type):
-                members[name] = cls.from_type(value, parent=key)
             elif isinstance(value, _Auto):
                 members[name] = value.build(f"{key}.{name}")
+            elif name.startswith("_"):
+                continue
+            elif isinstance(value, type):
+                members[name] = cls.from_type(value, parent=key)
             else:
                 members[name] = Option(f"{key}.{name}", default=value)
 


### PR DESCRIPTION
## Changelog
- Add the ability to define an option namespace using the `@Option.namespace` decorator
- Add the `Option.auto` method for defining options in a namespace with default values, docstrings, and `>>` transformations while still automatically determining the key


## See Also
- #12