### PR TITLE
Add `Option.set` method for setting a value in an options dictionary

### DIFF
--- a/labrea/option.py
+++ b/labrea/option.py
@@ -13,7 +13,12 @@ from typing import (
 )
 
 from confectioner import mix
-from confectioner.templating import dotted_key_exists, get_dotted_key, resolve
+from confectioner.templating import (
+    dotted_key_exists,
+    get_dotted_key,
+    resolve,
+    set_dotted_key,
+)
 
 from ._missing import MISSING, MaybeMissing
 from .application import FunctionApplication
@@ -234,6 +239,33 @@ class Option(Evaluatable[A]):
         '100'  # str transformation applied
         """
         return _Auto(default, doc)  # type: ignore
+
+    def set(self, options: Options, value: JSON) -> Options:
+        """Set the value of the option in the options dictionary.
+
+        Arguments
+        ----------
+        options : Options
+            The options dictionary to modify.
+        value : A
+            The value to set the option to.
+
+        Returns
+        -------
+        Options
+            The modified options dictionary
+
+
+        Example Usage
+        -------------
+        >>> from labrea import Option
+        >>> o = Option('A.Y')
+        >>> o.set({'A': {'X': 'foo'}}, 'bar')
+        {'A': {'X': 'foo', 'Y': 'bar'}}
+        """
+        new: Dict[str, JSON] = {}
+        set_dotted_key(self.key, value, new)
+        return mix(options, new)  # type: ignore
 
 
 class WithOptions(Evaluatable[B]):

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -288,3 +288,12 @@ def test_namespace_doc():
             B = Option.auto(1, doc="B")
 
     assert PKG.__doc__ == 'Namespace PKG:\n  Option PKG.A\n  Namespace PKG.MODULE:\n    Option PKG.MODULE.B (default 1): B'
+
+
+def test_set():
+    option = Option('A.B')
+    options = {'A': {'B': 0}, 'C': 1}
+
+    new = option.set(options, 2)
+    assert new is not options
+    assert new == {'A': {'B': 2}, 'C': 1}


### PR DESCRIPTION
## Example
```python
>>> from labrea import Option
>>> 
>>> OPT = Option('X.Y.Z')
>>> OPT.set({'A': 1}, 2)
{'A': 1, 'X': {'Y': {'Z': 2}}}
```