### PR TITLE
Add Option Namespaces

### DIFF
--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -1,5 +1,5 @@
 from labrea.exceptions import KeyNotFoundError
-from labrea.option import AllOptions, Option, WithOptions, WithDefaultOptions, UnrecognizedNamespaceMemberError, NAMESPACE_ALLOW_EXTRA
+from labrea.option import AllOptions, Option, WithOptions, WithDefaultOptions, UnrecognizedNamespaceMemberWarning
 from labrea.template import Template
 from labrea.types import Value
 import pytest
@@ -271,12 +271,8 @@ def test_namespace_extra():
 
     options = {"PKG": {"A": 1, "B": 2}}
 
-    with pytest.raises(UnrecognizedNamespaceMemberError):
+    with pytest.warns(UnrecognizedNamespaceMemberWarning):
         PKG.validate(options)
-
-    options = NAMESPACE_ALLOW_EXTRA.set(options, True)
-
-    PKG.validate(options)
 
 
 def test_namespace_default():


### PR DESCRIPTION
## Changelog
- New `Option.namespace` decorator allows for the creation of a namespace of options using a class definition
- `Option` keys are inferred based on the name of the attribute
- `Option`s can either be created with type annotations or with the `Option.auto()` method