### PR TITLE
Add stacked overloads

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -69,6 +69,23 @@ def test_overload_no_dispatch():
             pass
 
 
+def test_overload_stacked():
+    @dataset(dispatch='X')
+    def x():
+        pass
+
+    @x.overload('Y')
+    @dataset(dispatch='Y')
+    def y():
+        pass
+
+    @y.overload('Z')
+    def z():
+        return "foo"
+
+    assert x.evaluate({'X': 'Y', 'Y': 'Z'}) == "foo"
+
+
 def test_abstract():
 
     @abstractdataset(dispatch='A')


### PR DESCRIPTION
## Changelog
- Allow the `Dataset.overload` decorator to be stacked on another evaluatable
  + Enables nested overload dispatching  