### PR TITLE
Allow dataset definitions to have kwargs for use with @dataset.where

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -291,3 +291,12 @@ def test_pickle():
     x = dataset(Option('X'))
 
     assert isinstance(pickle.loads(pickle.dumps(x)), Dataset)
+
+
+def test_dataset_kwargs():
+    @dataset.where(x=Option('X'))
+    def y(**kwargs) -> dict:
+        return kwargs
+
+
+    assert y({'X': 1, 'Z': 2}) == {'x': 1}


### PR DESCRIPTION
## Changelog
- Allow dataset definitions to have `**kwargs`
  + This can be useful when using `@dataset.where` and wrapping an existing function with kwargs 