### PR TITLE
Add callbacks to datasets

### DIFF
--- a/labrea/pipeline.py
+++ b/labrea/pipeline.py
@@ -90,12 +90,16 @@ class PipelineStep(Evaluatable[Callable[[A], B]], Transformation[A, B]):
         return isinstance(other, PipelineStep) and self.step == other.step
 
 
+def _identity(x):
+    return x
+
+
 class _Identity(Generic[A], PipelineStep[A, A]):
     def __new__(cls) -> "_Identity[A]":
         return super().__new__(cls)
 
     def __init__(self) -> None:
-        super().__init__(Value(lambda x: x), "Identity")
+        super().__init__(Value(_identity), "Identity")
 
 
 Identity: _Identity = _Identity()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -8,6 +8,7 @@ from labrea.dataset import Dataset, dataset, abstractdataset
 from labrea.exceptions import EvaluationError
 from labrea.logging import LogRequest
 from labrea.option import Option
+from labrea.pipeline import Pipeline
 import labrea.runtime
 
 
@@ -291,3 +292,18 @@ def test_pickle():
     x = dataset(Option('X'))
 
     assert isinstance(pickle.loads(pickle.dumps(x)), Dataset)
+
+
+def test_callback():
+    @dataset(callback=lambda x: x + 1)
+    def x() -> int:
+        return 1
+
+    assert x() == 2
+
+
+    @dataset(callback=Pipeline() + (lambda x: x + 10) + (lambda x: x / 2))
+    def y() -> float:
+        return 1
+
+    assert y() == 5.5


### PR DESCRIPTION
## Changelog
- The `@dataset` decorator now takes an optional `callback` argument
- This can be any callable or `Evaluatable` that returns a callable
- The semantics are that this callback will be used to transform the value before any effects, caching, logging, etc are performed
- Callbacks are fixed at dataset definition time and cannot be modified
- Can be used to apply standard logic to the end of any overload