### PR TITLE
Add domain enforcement for Options

### DIFF
--- a/labrea/functions.py
+++ b/labrea/functions.py
@@ -48,6 +48,7 @@ def partial(
     Evaluatable[Callable[..., A]]
         An Evaluatable that returns a partially applied function.
 
+
     Example Usage
     -------------
     >>> from labrea import Option
@@ -193,8 +194,6 @@ def into(
     >>>
     >>> (Option('A') >> F.into(lambda x, y: x + y))({'A': [1, 2]})
     3
-    >>> (Option('A') >> F.into(lambda x, y: x + y))({'A': {'x': 1, 'y': 2}})
-    3
     """
 
     @pipeline_step
@@ -253,6 +252,7 @@ def map_items(
     PipelineStep[Mapping[K1, V1], Mapping[K2, V2]]
         A pipeline step that applies the function to the items of the mapping.
 
+
     Example Usage
     -------------
     >>> from labrea import Option
@@ -289,6 +289,7 @@ def map_keys(
     PipelineStep[Mapping[K1, V1], Mapping[K2, V1]]
         A pipeline step that applies the function to the keys of the mapping.
 
+
     Example Usage
     -------------
     >>> from labrea import Option
@@ -319,6 +320,7 @@ def map_values(
     PipelineStep[Mapping[K1, V1], Mapping[K1, V2]]
         A pipeline step that applies the function to the values of the mapping.
 
+
     Example Usage
     -------------
     >>> from labrea import Option
@@ -348,6 +350,7 @@ def filter_items(
     -------
     PipelineStep[Mapping[K1, V1], Mapping[K1, V1]]
         A pipeline step that filters the items of the mapping using the predicate function.
+
 
     Example Usage
     -------------
@@ -385,6 +388,7 @@ def filter_keys(
     PipelineStep[Mapping[K1, V1], Mapping[K1, V1]]
         A pipeline step that filters the keys of the mapping using the predicate function.
 
+
     Example Usage
     -------------
     >>> from labrea import Option
@@ -414,6 +418,7 @@ def filter_values(
     -------
     PipelineStep[Mapping[K1, V1], Mapping[K1, V1]]
         A pipeline step that filters the values of the mapping using the predicate function.
+
 
     Example Usage
     -------------

--- a/labrea/option.py
+++ b/labrea/option.py
@@ -119,21 +119,24 @@ class Option(Evaluatable[A]):
         self.__doc__ = doc
 
     def _enforce_domain(self, value: Any, options: Options) -> None:
-        if self.domain is not MISSING:
-            domain = self.domain.evaluate(options)
-            if callable(domain) and not domain(value):
-                raise ValueError(
-                    f"Value {value!r} for option {self.key} does not satisfy {self.domain!r}"
-                )
-            elif isinstance(domain, Container) and value not in domain:
-                raise ValueError(
-                    f"Value {value!r} for option {self.key} not in domain {domain!r}"
-                )
-            elif not callable(domain) and not isinstance(domain, Container):
-                warnings.warn(
-                    f"Domain {domain!r} for option {self.key} is not valid",
-                    RuntimeWarning,
-                )
+        if self.domain is MISSING:
+            return
+
+        domain = self.domain.evaluate(options)
+        if not callable(domain) and not isinstance(domain, Container):
+            warnings.warn(
+                f"Domain {domain!r} for option {self.key} is not valid",
+                RuntimeWarning,
+            )
+            return
+        if callable(domain) and not domain(value):
+            raise ValueError(
+                f"Value {value!r} for option {self.key} does not satisfy {self.domain!r}"
+            )
+        if isinstance(domain, Container) and value not in domain:
+            raise ValueError(
+                f"Value {value!r} for option {self.key} not in domain {domain!r}"
+            )
 
     def evaluate(self, options: Options) -> A:
         """Retrieves the key from the options dictionary.

--- a/labrea/option.py
+++ b/labrea/option.py
@@ -65,6 +65,15 @@ class Option(Evaluatable[A]):
         providing a default value directly.
     doc : str
         The docstring for the option.
+    type: Type[A]
+        The expected type of the option. Third-party packages can handle the
+        :class:`labrea.type_validation.TypeValidationRequest` to enforce
+        types
+    domain: MaybeMissing[MaybeEvaluatable[_Domain]]
+        A domain representing valid values for the option. The domain can be
+        a predicate function, a container of valid values, or an Evaluatable
+        that returns a predicate function or container of valid values
+        (e.g. a pipeline step).
 
 
     Example Usage
@@ -88,7 +97,7 @@ class Option(Evaluatable[A]):
         default: MaybeMissing[MaybeEvaluatable[A]] = MISSING,
         default_factory: MaybeMissing[Callable[[], A]] = MISSING,
         type: Type[A] = cast(Type, Any),
-        domain: MaybeMissing[_Domain] = MISSING,
+        domain: MaybeMissing[MaybeEvaluatable[_Domain]] = MISSING,
         doc: str = "",
     ) -> None:
         self.key = key

--- a/labrea/type_validation.py
+++ b/labrea/type_validation.py
@@ -1,0 +1,32 @@
+from typing import Any, Type
+
+from .runtime import Request
+from .types import Options
+
+
+class TypeValidationRequest(Request[None]):
+    """A request to validate a type.
+
+    Arguments
+    ---------
+    value : Any
+        The value to validate.
+    type : Type[A]
+        The type to validate against.
+    options : Options
+        The options used during evaluation.
+    """
+
+    value: Any
+    type: Type
+    options: Options
+
+    def __init__(self, value: Any, type: Type, options: Options):
+        self.value = value
+        self.type = type
+        self.options = options
+
+
+@TypeValidationRequest.handle
+def _empty_handler(request: TypeValidationRequest):
+    return

--- a/labrea/types.py
+++ b/labrea/types.py
@@ -4,10 +4,10 @@ from copy import deepcopy
 from typing import (
     Callable,
     Generic,
-    List,
     Mapping,
     Optional,
     Protocol,
+    Sequence,
     Set,
     TypeVar,
     Union,
@@ -20,7 +20,7 @@ from .exceptions import EvaluationError, InsufficientInformationError
 from .runtime import Request
 
 JSONScalar = Union[str, int, float, bool, None]
-JSON = Union[JSONScalar, Mapping[str, "JSON"], List["JSON"]]
+JSON = Union[JSONScalar, Mapping[str, "JSON"], Sequence["JSON"]]
 Options = Mapping[str, JSON]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ build-backend = "hatchling.build"
 [project]
 name = "labrea"
 authors = [
-    {name = "Austin Warner", email = "austin.warner@8451.com"},
-    {name = "Michael Stoepel", email = "michael.stoepel@8451.com"},
+    { name = "Austin Warner", email = "austin.warner@8451.com" },
+    { name = "Michael Stoepel", email = "michael.stoepel@8451.com" },
 ]
 description = "A framework for declarative, functional dataset definitions."
 readme = "README.md"
@@ -28,6 +28,7 @@ classifiers = [
 dependencies = [
     "typing_extensions>=4.0; python_version<\"3.11\"",
     "confectioner>=1.0,<2.0",
+    "pydantic",
 ]
 dynamic = ["version"]
 
@@ -43,12 +44,7 @@ documentation = "https://8451.github.io/labrea"
 bugs = "https://github.com/8451/labrea/issues"
 
 [project.optional-dependencies]
-test = [
-    "coverage",
-    "coverage-badge",
-    "pytest",
-    "pytest-cov",
-]
+test = ["coverage", "coverage-badge", "pytest", "pytest-cov"]
 doc = [
     "nbsphinx",
     "recommonmark",
@@ -70,9 +66,7 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = [
-    "tests/"
-]
+testpaths = ["tests/"]
 
 [tool.mypy]
 plugins = ["labrea.mypy.plugin"]

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -259,12 +259,14 @@ def test_namespace_explicit():
 def test_namespace_auto():
     @Option.namespace
     class PKG:
-        A = Option.auto(doc="A as string") >> str
-        B = Option.auto(doc="B")
+        A = Option.auto(doc="A as string", type=int, domain=[1]) >> str
+        B = Option.auto(doc="B", type=int, domain=[1])
 
     assert PKG.A({"PKG": {"A": 1}}) == "1"
     assert PKG.A.__doc__ == "A as string"
     assert PKG.B.__doc__ == "B"
+    assert PKG.B.type is int
+    assert PKG.B.domain() == [1]
 
 
 def test_namespace_extra():

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -1,7 +1,10 @@
+from typing import Any
 from labrea.exceptions import KeyNotFoundError
 from labrea.option import AllOptions, Option, WithOptions, WithDefaultOptions, UnrecognizedNamespaceMemberWarning
 from labrea.template import Template
+from labrea.type_validation import TypeValidationRequest
 from labrea.types import Value
+import labrea.runtime
 import pytest
 
 
@@ -311,3 +314,32 @@ def test_set():
     new = option.set(options, 2)
     assert new is not options
     assert new == {'A': {'B': 2}, 'C': 1}
+
+
+def test_type_validation():
+    store: TypeValidationRequest = TypeValidationRequest(None, Any, {})
+
+    def handle_type_validation(request: TypeValidationRequest):
+        nonlocal store
+        store = request
+        return request.value
+
+    implicit = Option[int]('A')
+    explicit = Option('A', type=int)
+
+    with labrea.runtime.current_runtime().handle(TypeValidationRequest, handle_type_validation):
+        implicit({'A': 1})
+        assert store.type is int
+        assert store.value == 1
+
+        implicit.validate({'A': 2})
+        assert store.type is int
+        assert store.value == 2
+
+        explicit({'A': 3})
+        assert store.type is int
+        assert store.value == 3
+
+        explicit.validate({'A': 4})
+        assert store.type is int
+        assert store.value == 4


### PR DESCRIPTION
## Changelog
- `Option` constructor now takes an optional `domain` argument
- This can be a container of values, a predicate function, or an `Evaluatable` that returns either of those things
- The domain is enforced during `.evaluate` and `.validate`