### PR TITLE
Add a bagillion new helper functions

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -124,18 +124,76 @@ Pipelines
 
 Pipeline Helper Functions
 -------------------------
+
+Generic
+~~~~~~~
+.. autofunction:: labrea.functions.partial
+.. autofunction:: labrea.functions.into
+
+Collections
+~~~~~~~~~~~
 .. autofunction:: labrea.functions.map
 .. autofunction:: labrea.functions.filter
 .. autofunction:: labrea.functions.reduce
+.. autofunction:: labrea.functions.flatten
 .. autofunction:: labrea.functions.flatmap
-.. autofunction:: labrea.functions.partial
-.. autofunction:: labrea.functions.into
 .. autofunction:: labrea.functions.map_items
 .. autofunction:: labrea.functions.map_keys
 .. autofunction:: labrea.functions.map_values
 .. autofunction:: labrea.functions.filter_items
 .. autofunction:: labrea.functions.filter_keys
 .. autofunction:: labrea.functions.filter_values
+.. autofunction:: labrea.functions.concat
+.. autofunction:: labrea.functions.append
+.. autofunction:: labrea.functions.intersect
+.. autofunction:: labrea.functions.union
+.. autofunction:: labrea.functions.difference
+.. autofunction:: labrea.functions.symmetric_difference
+.. autofunction:: labrea.functions.merge
+
+Math
+~~~~
+.. autofunction:: labrea.functions.add
+.. autofunction:: labrea.functions.subtract
+.. autofunction:: labrea.functions.multiply
+.. autofunction:: labrea.functions.divide
+.. autofunction:: labrea.functions.multiply_by
+.. autofunction:: labrea.functions.divide_by
+.. autofunction:: labrea.functions.negate
+.. autofunction:: labrea.functions.modulo
+
+
+Predicates
+~~~~~~~~~~
+.. autofunction:: labrea.functions.eq
+.. autofunction:: labrea.functions.ne
+.. autofunction:: labrea.functions.lt
+.. autofunction:: labrea.functions.le
+.. autofunction:: labrea.functions.gt
+.. autofunction:: labrea.functions.ge
+.. autofunction:: labrea.functions.positive
+.. autofunction:: labrea.functions.negative
+.. autofunction:: labrea.functions.non_positive
+.. autofunction:: labrea.functions.non_negative
+.. autofunction:: labrea.functions.is_none
+.. autofunction:: labrea.functions.is_not_none
+.. autofunction:: labrea.functions.has_remainder
+.. autofunction:: labrea.functions.even
+.. autofunction:: labrea.functions.odd
+.. autofunction:: labrea.functions.any
+.. autofunction:: labrea.functions.all
+.. autofunction:: labrea.functions.invert
+.. autofunction:: labrea.functions.instance_of
+.. autofunction:: labrea.functions.is_in
+.. autofunction:: labrea.functions.is_not_in
+.. autofunction:: labrea.functions.is_one_of
+.. autofunction:: labrea.functions.is_not_one_of
+.. autofunction:: labrea.functions.contains
+.. autofunction:: labrea.functions.does_not_contain
+.. autofunction:: labrea.functions.intersects
+.. autofunction:: labrea.functions.disjoint_from
+
+
 
 Templates
 ---------

--- a/labrea/functions.py
+++ b/labrea/functions.py
@@ -11,6 +11,7 @@ import itertools
 from types import MappingProxyType
 from typing import Any, Callable, Hashable, Iterable, Mapping, Tuple, TypeVar, Union
 
+from . import collections
 from ._missing import MISSING, MaybeMissing
 from .application import PartialApplication
 from .pipeline import Pipeline, PipelineStep, pipeline_step
@@ -431,4 +432,355 @@ def filter_values(
     return PipelineStep(
         filter_items(partial(lambda k, v, f: f(v), f=func)),
         f"filter_values({func!r})",
+    )
+
+
+def eq(value: Any) -> PipelineStep[Any, bool]:
+    """Create a pipeline step that checks if the input is equal to a value.
+
+    Arguments
+    ---------
+    value : Any
+        The value to compare the input to.
+
+    Returns
+    -------
+    PipelineStep[Any, bool]
+        A pipeline step that checks if the input is equal to the value.
+
+
+    Example Usage
+    -------------
+    >>> from labrea import Option
+    >>> import labrea.functions as F
+    >>>
+    >>> (Option('A') >> F.eq(1))({'A': 1})
+    True
+    """
+    return PipelineStep(
+        partial(lambda x, v: x == v, v=value),
+        f"eq({value!r})",
+    )
+
+
+def ne(value: Any) -> PipelineStep[Any, bool]:
+    """Create a pipeline step that checks if the input is not equal to a value.
+
+    Arguments
+    ---------
+    value : Any
+        The value to compare the input to.
+
+    Returns
+    -------
+    PipelineStep[Any, bool]
+        A pipeline step that checks if the input is not equal to the value.
+
+
+    Example Usage
+    -------------
+    >>> from labrea import Option
+    >>> import labrea.functions as F
+    >>>
+    >>> (Option('A') >> F.ne(1))({'A': 1})
+    False
+    """
+    return PipelineStep(
+        partial(lambda x, v: x != v, v=value),
+        f"ne({value!r})",
+    )
+
+
+def gt(value: Any) -> PipelineStep[Any, bool]:
+    """Create a pipeline step that checks if the input is greater than a value.
+
+    Arguments
+    ---------
+    value : Any
+        The value to compare the input to.
+
+    Returns
+    -------
+    PipelineStep[Any, bool]
+        A pipeline step that checks if the input is greater than the value.
+
+
+    Example Usage
+    -------------
+    >>> from labrea import Option
+    >>> import labrea.functions as F
+    >>>
+    >>> (Option('A') >> F.gt(1))({'A': 2})
+    True
+    """
+    return PipelineStep(
+        partial(lambda x, v: x > v, v=value),
+        f"gt({value!r})",
+    )
+
+
+def ge(value: Any) -> PipelineStep[Any, bool]:
+    """Create a pipeline step that checks if the input is greater than or equal to a value.
+
+    Arguments
+    ---------
+    value : Any
+        The value to compare the input to.
+
+    Returns
+    -------
+    PipelineStep[Any, bool]
+        A pipeline step that checks if the input is greater than or equal to the value.
+
+
+    Example Usage
+    -------------
+    >>> from labrea import Option
+    >>> import labrea.functions as F
+    >>>
+    >>> (Option('A') >> F.ge(1))({'A': 1})
+    True
+    """
+    return PipelineStep(
+        partial(lambda x, v: x >= v, v=value),
+        f"ge({value!r})",
+    )
+
+
+def lt(value: Any) -> PipelineStep[Any, bool]:
+    """Create a pipeline step that checks if the input is less than a value.
+
+    Arguments
+    ---------
+    value : Any
+        The value to compare the input to.
+
+    Returns
+    -------
+    PipelineStep[Any, bool]
+        A pipeline step that checks if the input is less than the value.
+
+
+    Example Usage
+    -------------
+    >>> from labrea import Option
+    >>> import labrea.functions as F
+    >>>
+    >>> (Option('A') >> F.lt(1))({'A': 0})
+    True
+    """
+    return PipelineStep(
+        partial(lambda x, v: x < v, v=value),
+        f"lt({value!r})",
+    )
+
+
+def le(value: Any) -> PipelineStep[Any, bool]:
+    """Create a pipeline step that checks if the input is less than or equal to a value.
+
+    Arguments
+    ---------
+    value : Any
+        The value to compare the input to.
+
+    Returns
+    -------
+    PipelineStep[Any, bool]
+        A pipeline step that checks if the input is less than or equal to the value.
+
+
+    Example Usage
+    -------------
+    >>> from labrea import Option
+    >>> import labrea.functions as F
+    >>>
+    >>> (Option('A') >> F.le(1))({'A': 1})
+    True
+    """
+    return PipelineStep(
+        partial(lambda x, v: x <= v, v=value),
+        f"le({value!r})",
+    )
+
+
+def has_remainder(
+    divisor: MaybeEvaluatable[int], reminder: MaybeEvaluatable[int]
+) -> PipelineStep[int, bool]:
+    """Create a pipeline step that checks if the input has a remainder when divided by a divisor.
+
+    Arguments
+    ---------
+    divisor : MaybeEvaluatable[int]
+        The divisor to divide the input by. This can be an Evaluatable that returns
+        a divisor, or a constant divisor.
+    reminder : MaybeEvaluatable[int]
+        The reminder to check if the input has when divided by the divisor. This can
+        be an Evaluatable that returns a reminder, or a constant reminder.
+
+    Returns
+    -------
+    PipelineStep[int, bool]
+        A pipeline step that checks if the input has a reminder when divided by the divisor.
+
+
+    Example Usage
+    -------------
+    >>> from labrea import Option
+    >>> import labrea.functions as F
+    >>>
+    >>> (Option('A') >> F.has_remainder(2, 1))({'A': 3})
+    True
+    """
+    return PipelineStep(
+        partial(
+            lambda x, d, r: x % d == r,
+            d=Evaluatable.ensure(divisor),
+            r=Evaluatable.ensure(reminder),
+        ),
+        f"has_remainder({divisor!r}, {reminder!r})",
+    )
+
+
+positive = gt(0)
+positive.__doc__ = "A pipeline step that checks if the input is positive."
+negative = lt(0)
+negative.__doc__ = "A pipeline step that checks if the input is negative."
+non_positive = le(0)
+non_positive.__doc__ = "A pipeline step that checks if the input is non-positive."
+non_negative = ge(0)
+non_negative.__doc__ = "A pipeline step that checks if the input is non-negative."
+is_even = has_remainder(2, 0)
+is_even.__doc__ = "A pipeline step that checks if the input is even."
+is_odd = has_remainder(2, 1)
+is_odd.__doc__ = "A pipeline step that checks if the input is odd."
+
+
+def instance_of(*types: MaybeEvaluatable[type]) -> PipelineStep[Any, bool]:
+    """Create a pipeline step that checks if the input is an instance of a type.
+
+    Arguments
+    ---------
+    *types : MaybeEvaluatable[type]
+        The types to check if the input is an instance of. These can be
+        Evaluatables that return types, or constant types.
+
+    Returns
+    -------
+    PipelineStep[Any, bool]
+        A pipeline step that checks if the input is an instance of the type.
+
+
+    Example Usage
+    -------------
+    >>> from labrea import Option
+    >>> import labrea.functions as F
+    >>>
+    >>> (Option('A') >> F.instance_of(int))({'A': 1})
+    True
+    """
+    return PipelineStep(
+        partial(
+            lambda x, t: isinstance(x, t),
+            t=collections.evaluatable_tuple(
+                *builtins.map(Evaluatable.ensure, types)  # type: ignore [arg-type]
+            ),
+        ),
+        f"instance_of({', '.join(builtins.map(repr, types))})",
+    )
+
+
+def all(*funcs: MaybeEvaluatable[Callable[[Any], bool]]) -> PipelineStep[Any, bool]:
+    """Create a pipeline step that checks if all functions return True for the input.
+
+    Arguments
+    ---------
+    *funcs : MaybeEvaluatable[Callable[[Any], bool]]
+        The functions to apply to the input. These can be Evaluatables that return
+        functions, or constant functions.
+
+    Returns
+    -------
+    PipelineStep[Any, bool]
+        A pipeline step that checks if all functions return True for the input.
+
+
+    Example Usage
+    -------------
+    >>> from labrea import Option
+    >>> import labrea.functions as F
+    >>>
+    >>> (Option('A') >> F.all(lambda x: x > 0, lambda x: x < 10))({'A': 5})
+    True
+    """
+    return PipelineStep(
+        partial(
+            lambda x, fs: builtins.all(f(x) for f in fs),
+            fs=collections.evaluatable_tuple(
+                *builtins.map(Evaluatable.ensure, funcs)  # type: ignore [arg-type]
+            ),
+        ),
+        f"all({', '.join(builtins.map(repr, funcs))})",
+    )
+
+
+def any(*funcs: MaybeEvaluatable[Callable[[Any], bool]]) -> PipelineStep[Any, bool]:
+    """Create a pipeline step that checks if any functions return True for the input.
+
+    Arguments
+    ---------
+    *funcs : MaybeEvaluatable[Callable[[Any], bool]]
+        The functions to apply to the input. These can be Evaluatables that return
+        functions, or constant functions.
+
+    Returns
+    -------
+    PipelineStep[Any, bool]
+        A pipeline step that checks if any functions return True for the input.
+
+
+    Example Usage
+    -------------
+    >>> from labrea import Option
+    >>> import labrea.functions as F
+    >>>
+    >>> (Option('A') >> F.any(lambda x: x < 0, lambda x: x > 10))({'A': 5})
+    False
+    """
+    return PipelineStep(
+        partial(
+            lambda x, fs: builtins.any(f(x) for f in fs),
+            fs=collections.evaluatable_tuple(
+                *builtins.map(Evaluatable.ensure, funcs)  # type: ignore [arg-type]
+            ),
+        ),
+        f"any({', '.join(builtins.map(repr, funcs))})",
+    )
+
+
+def is_not(func: MaybeEvaluatable[Callable[[Any], bool]]) -> PipelineStep[Any, bool]:
+    """Create a pipeline step that negates the result of a function.
+
+    Arguments
+    ---------
+    func : MaybeEvaluatable[Callable[[Any], bool]]
+        The function to negate the result of. This can be an Evaluatable that
+        returns a function, or a constant function.
+
+    Returns
+    -------
+    PipelineStep[Any, bool]
+        A pipeline step that negates the result of the function.
+
+
+    Example Usage
+    -------------
+    >>> from labrea import Option
+    >>> import labrea.functions as F
+    >>>
+    >>> (Option('A') >> F.not(lambda x: x < 0))({'A': 5})
+    True
+    """
+    return PipelineStep(
+        partial(lambda x, f: not f(x), f=Evaluatable.ensure(func)),
+        f"is_not({func!r})",
     )

--- a/labrea/functions.py
+++ b/labrea/functions.py
@@ -1630,3 +1630,71 @@ def disjoint_from(
         invert(intersects(iterable)),
         f"disjoint_from({iterable!r})",
     )
+
+
+def get_attribute(__name: MaybeEvaluatable[str]) -> PipelineStep[Any, Any]:
+    """Create a pipeline step that gets an attribute from the input.
+
+    Arguments
+    ---------
+    __name : MaybeEvaluatable[str]
+        The name of the attribute to get. This can be an Evaluatable that returns a string,
+        or a constant string.
+
+    Returns
+    -------
+    PipelineStep[Any, Any]
+        A pipeline step that gets the attribute from the input.
+
+
+    Example Usage
+    -------------
+    >>> from labrea import Option
+    >>> import labrea.functions as F
+    >>>
+    >>> (Option('A') >> F.get_attribute('upper'))({'A': 'hello'})
+    'HELLO'
+    """
+    return PipelineStep(
+        partial(lambda name, obj: getattr(obj, name), __name),
+        f"get_attribute({__name!r})",
+    )
+
+
+def _call_method(name: str, args: tuple, kwargs: dict, obj: Any) -> Any:
+    return getattr(obj, name)(*args, **kwargs)
+
+
+def call_method(
+    __name: MaybeEvaluatable[str], *args: Any, **kwargs: Any
+) -> PipelineStep[Any, Any]:
+    """Create a pipeline step that calls a method on the input.
+
+    Arguments
+    ---------
+    __name : MaybeEvaluatable[str]
+        The name of the method to call. This can be an Evaluatable that returns a string,
+        or a constant string.
+    *args : Any
+        The positional arguments to pass to the method.
+    **kwargs : Any
+        The keyword arguments to pass to the method.
+
+    Returns
+    -------
+    PipelineStep[Any, Any]
+        A pipeline step that calls the method on the input.
+
+
+    Example Usage
+    -------------
+    >>> from labrea import Option
+    >>> import labrea.functions as F
+    >>>
+    >>> (Option('A') >> F.call_method('upper'))({'A': 'hello'})
+    'HELLO'
+    """
+    return PipelineStep(
+        partial(_call_method, __name, args, kwargs),
+        f"call_method({__name!r}, {args!r}, {kwargs!r})",
+    )

--- a/labrea/functions.py
+++ b/labrea/functions.py
@@ -750,8 +750,7 @@ def get_from(
 ) -> PipelineStep[X, Union[Y, Z]]:
     """Create a pipeline step that gets a value from the input at the given key/index from the left.
 
-    This will reverse the operand order compared to :code:`get`, which is useful
-    when indexing is not commutative.
+    This will reverse the operand order compared to :code:`get`.
 
     Arguments
     ---------

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,4 +1,5 @@
 from labrea.option import Option
+from labrea.types import Value
 import labrea.functions as lf
 
 
@@ -373,3 +374,26 @@ def test_does_not_contain():
 
     assert a({'A': [1, 2, 3]}) == False
     assert a({'A': [2, 3]}) == True
+
+
+def test_get_attribute():
+    class Test:
+        def __init__(self, value):
+            self.value = value
+
+    a = Value(Test(1)) >> lf.get_attribute('value')
+
+    assert a() == 1
+
+
+def test_call_method():
+    class Test:
+        def __init__(self, value):
+            self.value = value
+
+        def method(self, x):
+            return self.value + x
+
+    a = Value(Test(1)) >> lf.call_method('method', 2)
+
+    assert a() == 3

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -77,6 +77,98 @@ def test_filter_values():
     assert f({'A': [[1, 1], [2, 2], [3, 3], [4, 4]]}) == {2: 2, 4: 4}
 
 
+def test_concat():
+    a = Option('A') >> lf.concat([1]) >> list
+
+    assert a({'A': [0]}) == [0, 1]
+
+
+def append():
+    a = Option('A') >> lf.append(1) >> list
+
+    assert a({'A': [0]}) == [0, 1]
+
+
+def test_intersect():
+    a = Option('A') >> lf.intersect([1, 2])
+
+    assert a({'A': [0, 1]}) == {1}
+
+
+def test_union():
+    a = Option('A') >> lf.union([1, 2])
+
+    assert a({'A': [0, 1]}) == {0, 1, 2}
+
+
+def test_difference():
+    a = Option('A') >> lf.difference([1, 2])
+
+    assert a({'A': [0, 1]}) == {0}
+
+
+def test_symmetric_difference():
+    a = Option('A') >> lf.symmetric_difference([1, 2])
+
+    assert a({'A': [0, 1]}) == {0, 2}
+
+
+def test_add():
+    a = Option('A') >> lf.add(1)
+
+    assert a({'A': 1}) == 2
+
+
+def test_subtract():
+    a = Option('A') >> lf.subtract(1)
+
+    assert a({'A': 1}) == 0
+
+
+def test_multiply():
+    a = Option('A') >> lf.multiply(2)
+
+    assert a({'A': 2}) == 4
+
+
+def test_divide():
+    a = Option('A') >> lf.divide_by(2)
+
+    assert a({'A': 4}) == 2
+
+
+def test_left_multiply():
+    a = Option('A') >> lf.left_multiply(2)
+
+    assert a({'A': 2}) == 4
+
+
+def test_divide_into():
+    a = Option('A') >> lf.divide_into(2)
+
+    assert a({'A': 4}) == 0.5
+
+
+def test_negate():
+    a = Option('A') >> lf.negate
+
+    assert a({'A': 1}) == -1
+    assert a({'A': -1}) == 1
+
+
+def test_merge():
+    a = Option('A') >> lf.merge({'B': 2})
+
+    assert a({'A': {'A': 0, 'B': 1}}) == {'A': 0, 'B': 2}
+
+
+
+def test_length():
+    a = Option('A') >> lf.length
+
+    assert a({'A': [0, 1]}) == 2
+
+
 def test_eq():
     e = Option('A') >> lf.eq(1)
 
@@ -123,6 +215,66 @@ def test_ge():
     assert e({'A': 2}) == True
 
 
+def test_positive():
+    a = Option('A') >> lf.positive
+
+    assert a({'A': -1}) == False
+    assert a({'A': 0}) == False
+    assert a({'A': 1}) == True
+
+
+def test_negative():
+    a = Option('A') >> lf.negative
+
+    assert a({'A': -1}) == True
+    assert a({'A': 0}) == False
+    assert a({'A': 1}) == False
+
+
+def test_non_positive():
+    a = Option('A') >> lf.non_positive
+
+    assert a({'A': -1}) == True
+    assert a({'A': 0}) == True
+    assert a({'A': 1}) == False
+
+
+def test_non_negative():
+    a = Option('A') >> lf.non_negative
+
+    assert a({'A': -1}) == False
+    assert a({'A': 0}) == True
+    assert a({'A': 1}) == True
+
+
+def test_even():
+    a = Option('A') >> lf.even
+
+    assert a({'A': 0}) == True
+    assert a({'A': 1}) == False
+
+
+def test_odd():
+    a = Option('A') >> lf.odd
+
+    assert a({'A': 0}) == False
+    assert a({'A': 1}) == True
+
+
+def test_is_none():
+    a = Option('A') >> lf.is_none
+
+    assert a({'A': None}) == True
+    assert a({'A': 0}) == False
+
+
+def test_is_not_none():
+    a = Option('A') >> lf.is_not_none
+
+    assert a({'A': None}) == False
+    assert a({'A': 0}) == True
+
+
 def test_instance_of():
     e = Option('A') >> lf.instance_of(int)
 
@@ -146,9 +298,64 @@ def test_any():
     assert a({'A': 2}) == True
 
 
-def test_is_not():
-    a = Option('A') >> lf.is_not(lf.eq(1))
+def test_invert():
+    a = Option('A') >> lf.invert(lf.eq(1))
 
     assert a({'A': 0}) == True
     assert a({'A': 1}) == False
     assert a({'A': 2}) == True
+
+    b = Option('B') >> lf.invert()
+
+    assert b({'B': True}) == False
+    assert b({'B': False}) == True
+
+
+def test_is_in():
+    a = Option('A') >> lf.is_in([1, 2])
+
+    assert a({'A': 0}) == False
+    assert a({'A': 1}) == True
+    assert a({'A': 2}) == True
+    assert a({'A': 3}) == False
+
+
+def test_is_not_in():
+    a = Option('A') >> lf.is_not_in([1, 2])
+
+    assert a({'A': 0}) == True
+    assert a({'A': 1}) == False
+    assert a({'A': 2}) == False
+    assert a({'A': 3}) == True
+
+
+def test_one_of():
+    a = Option('A') >> lf.one_of(1, 2)
+
+    assert a({'A': 0}) == False
+    assert a({'A': 1}) == True
+    assert a({'A': 2}) == True
+    assert a({'A': 3}) == False
+
+
+def test_none_of():
+    a = Option('A') >> lf.none_of(1, 2)
+
+    assert a({'A': 0}) == True
+    assert a({'A': 1}) == False
+    assert a({'A': 2}) == False
+    assert a({'A': 3}) == True
+
+
+def test_contains():
+    a = Option('A') >> lf.contains(1)
+
+    assert a({'A': [1, 2, 3]}) == True
+    assert a({'A': [2, 3]}) == False
+
+
+def test_does_not_contain():
+    a = Option('A') >> lf.does_not_contain(1)
+
+    assert a({'A': [1, 2, 3]}) == False
+    assert a({'A': [2, 3]}) == True

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -75,3 +75,80 @@ def test_filter_values():
     f = Option('A') >> dict >> lf.filter_values(lambda v: v % 2 == 0) >> dict
 
     assert f({'A': [[1, 1], [2, 2], [3, 3], [4, 4]]}) == {2: 2, 4: 4}
+
+
+def test_eq():
+    e = Option('A') >> lf.eq(1)
+
+    assert e({'A': 1}) == True
+    assert e({'A': 2}) == False
+
+
+def test_ne():
+    e = Option('A') >> lf.ne(1)
+
+    assert e({'A': 1}) == False
+    assert e({'A': 2}) == True
+
+
+def test_lt():
+    e = Option('A') >> lf.lt(1)
+
+    assert e({'A': 0}) == True
+    assert e({'A': 1}) == False
+    assert e({'A': 2}) == False
+
+
+def test_le():
+    e = Option('A') >> lf.le(1)
+
+    assert e({'A': 0}) == True
+    assert e({'A': 1}) == True
+    assert e({'A': 2}) == False
+
+
+def test_gt():
+    e = Option('A') >> lf.gt(1)
+
+    assert e({'A': 0}) == False
+    assert e({'A': 1}) == False
+    assert e({'A': 2}) == True
+
+
+def test_ge():
+    e = Option('A') >> lf.ge(1)
+
+    assert e({'A': 0}) == False
+    assert e({'A': 1}) == True
+    assert e({'A': 2}) == True
+
+
+def test_instance_of():
+    e = Option('A') >> lf.instance_of(int)
+
+    assert e({'A': 1}) == True
+    assert e({'A': '1'}) == False
+
+
+def test_all():
+    a = Option('A') >> lf.all(lf.gt(1), lf.lt(2))
+
+    assert a({'A': 1}) == False
+    assert a({'A': 1.5}) == True
+    assert a({'A': 2}) == False
+
+
+def test_any():
+    a = Option('A') >> lf.any(lf.le(1), lf.ge(2))
+
+    assert a({'A': 1}) == True
+    assert a({'A': 1.5}) == False
+    assert a({'A': 2}) == True
+
+
+def test_is_not():
+    a = Option('A') >> lf.is_not(lf.eq(1))
+
+    assert a({'A': 0}) == True
+    assert a({'A': 1}) == False
+    assert a({'A': 2}) == True

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -113,6 +113,20 @@ def test_symmetric_difference():
     assert a({'A': [0, 1]}) == {0, 2}
 
 
+def test_get():
+    a = Option('A') >> lf.get('B')
+    b = Option('A') >> lf.get('B', None)
+    c = Option('A') >> lf.get(1)
+    d = Option('A') >> lf.get(1, default=100)
+
+    assert a({'A': {'B': 'b'}}) == 'b'
+    assert b({'A': {'B': 'b'}}) == 'b'
+    assert b({'A': {'C': 'c'}}) is None
+    assert c({'A': [1, 2]}) == 2
+    assert d({'A': [1, 2]}) == 2
+    assert d({'A': [1]}) == 100
+
+
 def test_add():
     a = Option('A') >> lf.add(1)
 


### PR DESCRIPTION
## Changelog
- Add new helper functions in `labrea.functions`.
  + `flatten`
  + `concat`
  + `concat`
  + `append`
  + `intersect`
  + `union`
  + `difference`
  + `symmetric_difference`
  + `merge`
  + `add`
  + `subtract`
  + `multiply`
  + `divide`
  + `multiply_by`
  + `divide_by`
  + `negate`
  + `modulo`
  + `eq`
  + `ne`
  + `lt`
  + `le`
  + `gt`
  + `ge`
  + `positive`
  + `negative`
  + `non_positive`
  + `non_negative`
  + `is_none`
  + `is_not_none`
  + `has_remainder`
  + `even`
  + `odd`
  + `any`
  + `all`
  + `invert`
  + `instance_of`
  + `is_in`
  + `is_not_in`
  + `is_one_of`
  + `is_not_one_of`
  + `contains`
  + `does_not_contain`
  + `intersects`
  + `disjoint_from`
  + `ensure`
  + `get_attribute`
  + `call_method`